### PR TITLE
Use the term "signed by a private CA" instead of "self-signed certificates"

### DIFF
--- a/src/modules/esdbConfig/components/result/Certificates.vue
+++ b/src/modules/esdbConfig/components/result/Certificates.vue
@@ -17,7 +17,7 @@
       <div v-else>
         We have a <a href="https://developers.eventstore.com/server/v20/security/configuration.html#certificate-generation-cli" target="_blank">certificate
         generation
-        tool</a>, which creates certificated adopted for EventStoreDB.<br><br>
+        tool</a>, which creates certificated adapted for EventStoreDB.<br><br>
 
         <ElDivider content-position="right">Download the tool</ElDivider>
 
@@ -62,7 +62,7 @@
 
         <ElDivider content-position="right">Generate certificates for nodes</ElDivider>
 
-        You need to generate self-signed certificates for each node as described below.
+        You need to generate certificates signed by the CA for each node as described below.
 
         <NodeCertificate
                 v-for="node in config.nodes"

--- a/src/modules/esdbConfig/components/security/Security.vue
+++ b/src/modules/esdbConfig/components/security/Security.vue
@@ -21,7 +21,7 @@
                 label="Certificate:"
                 prop="cert">
           <ElRadioGroup v-model="cert">
-            <ElRadioButton label="self-signed">Self-signed</ElRadioButton>
+            <ElRadioButton label="self-signed">Private CA</ElRadioButton>
             <ElRadioButton label="trusted">Public CA</ElRadioButton>
           </ElRadioGroup>
         </ElFormItem>

--- a/src/modules/esdbConfig/domain/security.js
+++ b/src/modules/esdbConfig/domain/security.js
@@ -56,8 +56,8 @@ export default new Vue({
         },
         certCnHelp() {
             return this.isSelfSigned
-                ? "Must be <code>eventstoredb-node</code> for self-signed certificate."
-                : `You need a ${this.isCluster ? "wildcard " : ""}certificate signed by a public trusted CA.`;
+                ? "Must be <code>eventstoredb-node</code> for a certificate signed by a private CA."
+                : `You need a ${this.isCluster ? "wildcard " : ""}certificate signed by a publicly trusted CA.`;
         }
     },
 


### PR DESCRIPTION
- Use the term "signed by a private CA" instead of "self-signed certificates"
- Fix typo